### PR TITLE
Bugfix for ajaxterm

### DIFF
--- a/ajaxterm/ajaxterm.py
+++ b/ajaxterm/ajaxterm.py
@@ -19,6 +19,7 @@ class Terminal:
 	def init(self):
 		self.esc_seq={
 			"\x00": None,
+			"\x01": None,
 			"\x05": self.esc_da,
 			"\x07": None,
 			"\x08": self.esc_0x08,


### PR DESCRIPTION
Added an ignore entry for ascii 0x01, which would cause
the terminal to hang whenever a telnet session was started

See https://github.com/antonylesuisse/qweb/issues/4
