### PR TITLE
Fix arguments with spaces in ajaxterm runner

### DIFF
--- a/ajaxterm/configure.ajaxterm.bin
+++ b/ajaxterm/configure.ajaxterm.bin
@@ -1,2 +1,2 @@
 #!/bin/sh
-PYTHONPATH=%(lib)s exec %(lib)s/ajaxterm.py $@
+PYTHONPATH=%(lib)s exec %(lib)s/ajaxterm.py "$@"


### PR DESCRIPTION
Without this patch, it is impossible to pass command with arguments in '-c', for example
`ajaxterm -c "telnet myhost 1234"`
