### PR TITLE
Modify CSS styles to fix screen layout

### DIFF
--- a/ajaxterm/ajaxterm.css
+++ b/ajaxterm/ajaxterm.css
@@ -23,7 +23,8 @@ pre.stat .off {
 	color: white;
 	cursor: pointer;
 }
-pre.term {
+#term {
+	float: left;
 	margin: 0px;
 	padding: 4px;
 	display: block;
@@ -33,32 +34,29 @@ pre.term {
 	border-top: 1px solid white;
 	color: #eee;
 }
-pre.term span.f0  { color: #000; }
-pre.term span.f1  { color: #b00; }
-pre.term span.f2  { color: #0b0; }
-pre.term span.f3  { color: #bb0; }
-pre.term span.f4  { color: #00b; }
-pre.term span.f5  { color: #b0b; }
-pre.term span.f6  { color: #0bb; }
-pre.term span.f7  { color: #bbb; }
-pre.term span.f8  { color: #666; }
-pre.term span.f9  { color: #f00; }
-pre.term span.f10 { color: #0f0; }
-pre.term span.f11 { color: #ff0; }
-pre.term span.f12 { color: #00f; }
-pre.term span.f13 { color: #f0f; }
-pre.term span.f14 { color: #0ff; }
-pre.term span.f15 { color: #fff; }
-pre.term span.b0  { background-color: #000; }
-pre.term span.b1  { background-color: #b00; }
-pre.term span.b2  { background-color: #0b0; }
-pre.term span.b3  { background-color: #bb0; }
-pre.term span.b4  { background-color: #00b; }
-pre.term span.b5  { background-color: #b0b; }
-pre.term span.b6  { background-color: #0bb; }
-pre.term span.b7  { background-color: #bbb; }
+span.f0  { color: #000; }
+span.f1  { color: #b00; }
+span.f2  { color: #0b0; }
+span.f3  { color: #bb0; }
+span.f4  { color: #00b; }
+span.f5  { color: #b0b; }
+span.f6  { color: #0bb; }
+span.f7  { color: #bbb; }
+span.f8  { color: #666; }
+span.f9  { color: #f00; }
+span.f10 { color: #0f0; }
+span.f11 { color: #ff0; }
+span.f12 { color: #00f; }
+span.f13 { color: #f0f; }
+span.f14 { color: #0ff; }
+span.f15 { color: #fff; }
+span.b0  { background-color: #000; }
+span.b1  { background-color: #b00; }
+span.b2  { background-color: #0b0; }
+span.b3  { background-color: #bb0; }
+span.b4  { background-color: #00b; }
+span.b5  { background-color: #b0b; }
+span.b6  { background-color: #0bb; }
+span.b7  { background-color: #bbb; }
 
 body { background-color: #888; }
-#term {
-	float: left;
-}


### PR DESCRIPTION
The selector pre.term does not match any HTML node on recent versions of Firefox and Chromium, so the corresponding styles were not applied
